### PR TITLE
Update DS105L8.ipynb

### DIFF
--- a/DS105-Intermediate-Statistics/DS105L8.ipynb
+++ b/DS105-Intermediate-Statistics/DS105L8.ipynb
@@ -327,6 +327,8 @@
     "\n",
     "```{r}\n",
     "kickstarter3 <- as.matrix(kickstarter2)\n",
+    "kickstarter4 <- na.omit(kickstarter3)\n",
+    "mshapiro.test(t(kickstarter4))\n",
     "```\n",
     "\n",
     "You are now ready to perform the assumptions test for multivariate normality on ```kickstarter3```.\n",


### PR DESCRIPTION
on page 3:
kickstarter4 <- na.omit(kickstarter3)
mshapiro.test(t(kickstarter4))
{run the na.omit before trying the Wilks-Sharpiro Test}

Make mention of the numeric to categorical conversion for the IV sex (changed to sexfactor for the Hands On
heartAttacks$sexfactor= as.factor(heartAttacks$sex)

More grammatical and punctuation edits to come later!